### PR TITLE
NXP-33719: Upgrade OS packages in tester image to fix gnutls28 CVEs

### DIFF
--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -8,10 +8,14 @@ LABEL org.nuxeo.build-tag=$BUILD_TAG
 LABEL org.nuxeo.scm-ref=$SCM_REF
 LABEL org.nuxeo.version=$NUXEO_VERSION
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  curl \
-  jq \
-  wget \
+# Upgrade OS packages to pick up security fixes from Debian
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
+    curl \
+    jq \
+    wget \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 COPY scripts /scripts


### PR DESCRIPTION
## Context

The GCP Marketplace vulnerability scanner rejected a recent submission of the `tester` image with the following report:

```
Image: gcr.io/cloud-launcher-images-prd/hyl-is-marketplace/nuxeo/tester@sha256:9ea1d59cb5fda73fc465d40114f45c050ae82463811bf75da7ad8f084ef14c52

  Note: CVE-2026-33845
  Package: gnutls28
  Package Type: OS
  Affected Version: 3.7.9-2+deb12u3
  Fixed Version:    3.7.9-2+deb12u7

  Note: CVE-2026-42010
  Package: gnutls28
  Package Type: OS
  Affected Version: 3.7.9-2+deb12u3
  Fixed Version:    3.7.9-2+deb12u7
```

## Root cause

`gnutls28` (binary: `libgnutls30`) is not installed by `tester/Dockerfile` — it comes from the upstream base image `gcr.io/cloud-marketplace-tools/testrunner`, which is built on Debian 12 (bookworm). The base image was last published with the vulnerable version `3.7.9-2+deb12u3`, while Debian security has since released `3.7.9-2+deb12u7`.

## Fix

Added `apt-get upgrade -y` to the existing `RUN` step in `tester/Dockerfile`. This pulls all available security fixes from Debian's archives during build (including the patched `libgnutls30`), without changing the base image.

Also added `apt-get clean` for hygiene and a comment explaining the intent.

## Verification

Built the patched image locally and confirmed the upgrade:

```
$ docker run --rm --entrypoint="" <patched-image> dpkg-query -W -f='${Package} ${Version}\n' | grep gnutls
libgnutls30 3.7.9-2+deb12u7   ← matches GCP's required Fixed Version
```

## Scope: why only `tester/Dockerfile`?

The `deployer` image was not flagged by GCP. Its base image (`gcr.io/cloud-marketplace-tools/k8s/deployer_helm/onbuild`) is built [on Ubuntu 22.04, not Debian 12](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/marketplace/deployer_helm_base/Dockerfile), so the `+deb12u*` versions of `gnutls28` do not apply to it. The upstream `deployer_helm` Dockerfile already runs `apt-get upgrade -y` during its own build, so no change is needed here.

## Trade-off note

`apt-get upgrade` makes builds non-reproducible (installed versions depend on the state of Debian's security archive at build time). This is the conventional trade-off for marketplace-hardened images: it auto-pulls future CVE fixes without manual intervention. If strict reproducibility is needed later, individual packages can be pinned (e.g. `libgnutls30=3.7.9-2+deb12u7`) but each new CVE would then require a manual bump.

## Next steps after merge

1. The Jenkins pipeline (`ci/Jenkinsfiles/build.groovy`) will rebuild and push new image digests.
2. Resubmit the new image digests in the [GCP Marketplace producer portal](https://console.cloud.google.com/producer-portal/listing-edit/nuxeo.endpoints.hyl-is-marketplace.cloud.goog;stepId=kubernetesImages).
